### PR TITLE
Decouple lookup and OAuth2 token authentication

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,5 @@ omit=
 	runtests.py
 	makemigrations.py
 	*/tests/*
+	.tox/*
+	*/migrations/*

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,8 @@ indent_size=4
 [*.yml]
 indent_style=space
 indent_size=2
+
+[*.py]
+indent_style=space
+indent_size=4
+max_line_length=99

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=99
-exclude = venv,.tox,automationlookup/migrations
+exclude = venv,.tox,*/migrations

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ be defined within the including project.
 
 | Setting | Description |
 | ------- | ----------- |
+| OAUTH2_INTROSPECT_SCOPES | List of OAuth2 scopes the API server will request for the token it will use with the token introspection endpoint. |
+| OAUTH2_INTROSPECT_URL | URL of the OAuth2 token introspection endpoint. The API server will first identify itself to the OAuth2 token endpoint and request an access token for this endpoint. |
+| OAUTH2_TOKEN_URL | URL of the OAuth2 token endpoint the API server uses to request an authorisation token to perform OAuth2 token introspection. |
 | OAUTH2_CLIENT_ID | OAuth2 client id which the API server uses to identify itself to the OAuth2 token introspection endpoint. |
 | OAUTH2_CLIENT_SECRET | OAuth2 client secret which the API server uses to identify itself to the OAuth2 token introspection endpoint. |
 | OAUTH2_TOKEN_URL | URL of the OAuth2 token endpoint the API server uses to request an authorisation token to perform OAuth2 token introspection. |
@@ -56,5 +59,6 @@ be defined within the including project.
 | OAUTH2_INTROSPECT_SCOPES | List of OAuth2 scopes the API server will request for the token it will use with the token introspection endpoint. |
 | OAUTH2_LOOKUP_SCOPES | List of OAuth2 scopes the API server will request for the token it will use with lookup. |
 | OAUTH2_MAX_RETRIES | Maximum number of retries when fetching URLs from the OAuth2 endpoint or OAuth2 authenticated URLs. This applies only to failed DNS lookups, socket connections and connection timeouts, never to requests where data has made it to the server. |
+| LOOKUP_OAUTH2_SCOPES | List of OAuth2 scopes the API server will request for the token it will use with lookup. |
 | LOOKUP_ROOT | URL of the lookup proxy's API root. |
 | LOOKUP_PEOPLE_CACHE_LIFETIME | Responses to the people endpoint of lookupproxy are cached to increase performance. We assume that lookup details on people change rarely. This setting specifies the lifetime of a single cached lookup resource for a person in seconds. |

--- a/automationlookup/__init__.py
+++ b/automationlookup/__init__.py
@@ -1,0 +1,85 @@
+"""
+The :py:mod:`automationlookup` module provides functionality for integrating with the UIS
+Automation Lookup proxy service.
+
+"""
+from urllib.parse import urljoin, urlencode
+from django.conf import settings
+from django.core.cache import cache
+
+from automationoauth.client import AuthenticatedSession
+
+default_app_config = 'automationlookup.apps.AutomationLookupConfig'
+
+
+def get_person(identifier, scheme='crsid', fetch=None, session=None):
+    """
+    Return the resource from Lookup associated with the specified user. A requests package
+    :py:class:`HTTPError` is raised if the request fails.
+
+    :param str identifier: Lookup identifier for person
+    :param str scheme: Lookup scheme for person
+    :param list[str] fetch: List of additional attributes to fetch for the person.
+    :param :py:class:`automationoauth.client.AuthenticatedSession` session: Authenticated session
+       for calling Lookup proxy API.
+
+    If *session* is ``None``, the return value from :py:func:`~.get_authenticated_session` is used.
+
+    The result of this function call is cached based on the arguments to the call so it is safe to
+    call this multiple times.
+
+    """
+    # Use default session is not specified
+    session = session if session is not None else get_authenticated_session()
+
+    # Form the key for the django cache from the identifier, scheme and id of the session object
+    fetch_key = '' if fetch is None else ','.join(fetch)
+    cache_key = 'lookup:get_person:{identifier}:{scheme}:{fetch_key}:{session}'.format(
+        identifier=identifier, scheme=scheme, fetch_key=fetch_key, session=id(session))
+
+    # return a cached response if we have it
+    cached_resource = cache.get(cache_key)
+    if cached_resource is not None:
+        return cached_resource
+
+    # Ask lookup about this person
+    params = {}
+    if fetch is not None and len(fetch) > 0:
+        params['fetch'] = ','.join(fetch)
+
+    endpoint = 'people/{scheme}/{identifier}'.format(
+        scheme=scheme, identifier=identifier)
+    if params != {}:
+        endpoint += '?' + urlencode(params)
+
+    lookup_response = session.request(
+        method='GET', url=urljoin(settings.LOOKUP_ROOT, endpoint))
+
+    # Raise if there was an error
+    lookup_response.raise_for_status()
+
+    # save cached value
+    cache.set(cache_key, lookup_response.json(),
+              settings.LOOKUP_RESPONSE_CACHE_LIFETIME)
+
+    # recurse, which should now retrieve the value from the cache
+    return get_person(identifier, scheme, fetch=fetch, session=session)
+
+
+def get_authenticated_session():
+    """
+    Return a :py:mod:`automationoauth.client.AuthenticatedSession` instance pre-authenticated with
+    the required OAuth2 scopes to access the lookup proxy.
+
+    The return value is cached.
+
+    For compatibility with the legacy API, the OAUTH2_LOOKUP_SCOPES setting is used in preference
+    to LOOKUP_OAUTH2_SCOPES if it is present.
+
+    """
+    cached_session = getattr(get_authenticated_session, '_cached_session', None)
+    if cached_session is not None:
+        return cached_session
+    scopes = getattr(settings, 'OAUTH2_LOOKUP_SCOPES', settings.LOOKUP_OAUTH2_SCOPES)
+    get_authenticated_session._cached_session = AuthenticatedSession(scopes=scopes)
+    return get_authenticated_session()

--- a/automationlookup/apps.py
+++ b/automationlookup/apps.py
@@ -1,0 +1,33 @@
+from django.apps import AppConfig
+from django.conf import settings
+
+from . import defaultsettings
+
+
+class AutomationLookupConfig(AppConfig):
+    """Configuration for automationlookup application."""
+    #: The short name for this application.
+    name = 'automationlookup'
+
+    #: The human-readable verbose name for this application.
+    verbose_name = 'UIS AUotmation Lookup utilities'
+
+    def ready(self):
+        """
+        Perform application initialisation once the Django platform has been initialised.
+
+        """
+        super().ready()
+
+        # Register default settings in a rather ugly way since Django does not have a cleaner way
+        # for apps to register default settings.  https://stackoverflow.com/questions/8428556/
+
+        # Get a dictionary of settings. Only non private variables with upper case names are used.
+        default_setting_values = {
+            name: value for name, value in defaultsettings.__dict__.items()
+            if not name.startswith('_') and name.upper() == name
+        }
+
+        # Apply this dictionary to the settings
+        for name, default_value in default_setting_values.items():
+            setattr(settings, name, getattr(settings, name, default_value))

--- a/automationlookup/apps.py
+++ b/automationlookup/apps.py
@@ -10,7 +10,7 @@ class AutomationLookupConfig(AppConfig):
     name = 'automationlookup'
 
     #: The human-readable verbose name for this application.
-    verbose_name = 'UIS AUotmation Lookup utilities'
+    verbose_name = 'UIS Automation Lookup utilities'
 
     def ready(self):
         """

--- a/automationlookup/defaultsettings.py
+++ b/automationlookup/defaultsettings.py
@@ -1,0 +1,27 @@
+"""
+Default settings values for the :py:mod:`automationlookup` application.
+
+"""
+# Variables whose names are in upper case and do not start with an underscore from this module are
+# used as default settings for the automationlookup application. See AutomationLookupConfig in
+# .apps for how this is achieved. This is a bit mucky but, at the moment, Django does not have a
+# standard way to specify default values for settings.  See:
+# https://stackoverflow.com/questions/8428556/
+
+LOOKUP_ROOT = 'https://lookupproxy.automation.uis.cam.ac.uk/'
+"""
+Root of lookup proxy API.
+
+"""
+
+LOOKUP_RESPONSE_CACHE_LIFETIME = 30
+"""
+Lifetime of the cached lookup response in seconds.
+
+"""
+
+LOOKUP_OAUTH2_SCOPES = ['lookup:anonymous']
+"""
+OAuth2 scopes which are required to access the lookupproxy API.
+
+"""

--- a/automationlookup/tests/test_lookup.py
+++ b/automationlookup/tests/test_lookup.py
@@ -40,13 +40,13 @@ class LookupTests(TestCase):
             'institutions': [{'instid': 'INSTA'}, {'instid': 'INSTB'}],
         }
 
-        with self.mocked_session() as LOOKUP_SESSION:
-            LOOKUP_SESSION.request.return_value.json.return_value = mock_response
+        with self.mocked_session():
+            self.session.request.return_value.json.return_value = mock_response
             response = lookup.get_person_for_user(self.user)
 
         self.assertEqual(response, mock_response)
-        LOOKUP_SESSION.request.assert_called_once_with(
-            url='http://lookupproxy.invalid/people/mock/test0001?fetch=all_insts,all_groups',
+        self.session.request.assert_called_once_with(
+            url='http://lookupproxy.invalid/people/mock/test0001?fetch=all_insts%2Call_groups',
             method='GET'
         )
 
@@ -57,16 +57,18 @@ class LookupTests(TestCase):
             'institutions': [{'instid': 'INSTA'}, {'instid': 'INSTB'}],
         }
 
-        with self.mocked_session() as LOOKUP_SESSION:
-            LOOKUP_SESSION.request.return_value.json.return_value = mock_response
+        with self.mocked_session():
+            self.session.request.return_value.json.return_value = mock_response
             lookup.get_person_for_user(self.user)
             lookup.get_person_for_user(self.user)
 
-        LOOKUP_SESSION.request.assert_called_once_with(
-            url='http://lookupproxy.invalid/people/mock/test0001?fetch=all_insts,all_groups',
+        self.session.request.assert_called_once_with(
+            url='http://lookupproxy.invalid/people/mock/test0001?fetch=all_insts%2Call_groups',
             method='GET'
         )
 
     def mocked_session(self):
-        """Return a patch for the assets.lookup.LOOKUP_SESSION object."""
-        return mock.patch('automationlookup.lookup.LOOKUP_SESSION')
+        """Return a patch for the get_authenticated_session function."""
+        self.session = mock.MagicMock()
+        self.session.request.return_value.json.return_value = {}
+        return mock.patch('automationlookup.get_authenticated_session', return_value=self.session)

--- a/automationoauth/__init__.py
+++ b/automationoauth/__init__.py
@@ -1,0 +1,6 @@
+"""
+The :py:mod:`automationoauth` module provides functionality for integrating with the UIS Automation
+OAuth2 infrastructure.
+
+"""
+default_app_config = 'automationoauth.apps.AutomationOAuthConfig'

--- a/automationoauth/apps.py
+++ b/automationoauth/apps.py
@@ -1,0 +1,33 @@
+from django.apps import AppConfig
+from django.conf import settings
+
+from . import defaultsettings
+
+
+class AutomationOAuthConfig(AppConfig):
+    """Configuration for automationoauth application."""
+    #: The short name for this application.
+    name = 'automationoauth'
+
+    #: The human-readable verbose name for this application.
+    verbose_name = 'UIS AUotmation OAuth utilities'
+
+    def ready(self):
+        """
+        Perform application initialisation once the Django platform has been initialised.
+
+        """
+        super().ready()
+
+        # Register default settings in a rather ugly way since Django does not have a cleaner way
+        # for apps to register default settings.  https://stackoverflow.com/questions/8428556/
+
+        # Get a dictionary of settings. Only non private variables with upper case names are used.
+        default_setting_values = {
+            name: value for name, value in defaultsettings.__dict__.items()
+            if not name.startswith('_') and name.upper() == name
+        }
+
+        # Apply this dictionary to the settings
+        for name, default_value in default_setting_values.items():
+            setattr(settings, name, getattr(settings, name, default_value))

--- a/automationoauth/apps.py
+++ b/automationoauth/apps.py
@@ -10,7 +10,7 @@ class AutomationOAuthConfig(AppConfig):
     name = 'automationoauth'
 
     #: The human-readable verbose name for this application.
-    verbose_name = 'UIS AUotmation OAuth utilities'
+    verbose_name = 'UIS Automation OAuth utilities'
 
     def ready(self):
         """

--- a/automationoauth/client.py
+++ b/automationoauth/client.py
@@ -1,0 +1,57 @@
+"""
+The :py:mod:`automationoauth.client` module provides a wrapper around :py:class:`requests.Session`
+which is pre-authorised with an OAuth2 client token.
+
+"""
+from django.conf import settings
+from requests_oauthlib import OAuth2Session
+from requests.adapters import HTTPAdapter
+from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
+
+
+class AuthenticatedSession:
+    """
+    Maintain an authenticated session as a particular OAuth2 client. The client id and secret are
+    specified in the :py:attr:`~automationoauth.defaultsettings.OAUTH2_CLIENT_ID` and
+    :py:attr:`~automationoauth.defaultsettings.OAUTH2_CLIENT_SECRET` settings.
+
+    :param sequence scopes: A sequence of strings specifying the scopes which should be requested
+        for the token.
+
+    """
+    def __init__(self, scopes):
+        self._scopes = scopes
+        self._session = None
+
+    def _get_session(self):
+        """
+        Get a :py:class:`requests.Session` object which is authenticated with the API application's
+        OAuth2 client credentials.
+
+        """
+        client = BackendApplicationClient(client_id=settings.OAUTH2_CLIENT_ID)
+        session = OAuth2Session(client=client)
+        adapter = HTTPAdapter(max_retries=settings.OAUTH2_MAX_RETRIES)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        session.fetch_token(
+            timeout=2, token_url=settings.OAUTH2_TOKEN_URL,
+            client_id=settings.OAUTH2_CLIENT_ID,
+            client_secret=settings.OAUTH2_CLIENT_SECRET,
+            scope=self._scopes)
+        return session
+
+    def request(self, *args, **kwargs):
+        """
+        A version of :py:func:`requests.request` which is authenticated with the OAuth2 token for
+        this client. If the token has timed out, it is requested again.
+
+        """
+        if self._session is None:
+            self._session = self._get_session()
+
+        try:
+            return self._session.request(*args, **kwargs)
+        except TokenExpiredError:
+            self._session = self._get_session()
+            return self._session.request(*args, **kwargs)

--- a/automationoauth/defaultsettings.py
+++ b/automationoauth/defaultsettings.py
@@ -1,0 +1,51 @@
+"""
+Default settings values for the :py:mod:`automationoauth` application.
+
+"""
+# Variables whose names are in upper case and do not start with an underscore from this module are
+# used as default settings for the lookupapi application. See AutomationOAuthConfig in .apps for
+# how this is achieved. This is a bit mucky but, at the moment, Django does not have a standard way
+# to specify default values for settings.  See: https://stackoverflow.com/questions/8428556/
+
+OAUTH2_CLIENT_ID = None
+"""
+OAuth2 client id which the API server uses to identify itself to the OAuth2 token introspection
+endpoint.
+
+"""
+
+OAUTH2_CLIENT_SECRET = None
+"""
+OAuth2 client secret which the API server uses to identify itself to the OAuth2 token introspection
+endpoint.
+
+"""
+
+OAUTH2_TOKEN_URL = None
+"""
+URL of the OAuth2 token endpoint the API server uses to request an authorisation token to perform
+OAuth2 token introspection.
+
+"""
+
+OAUTH2_INTROSPECT_URL = None
+"""
+URL of the OAuth2 token introspection endpoint. The API server will first identify itself to the
+OAuth2 token endpoint and request an access token for this endpoint.
+
+"""
+
+OAUTH2_INTROSPECT_SCOPES = ['hydra.introspect'],
+"""
+List of OAuth2 scopes the API server will request for the token it will use with the token
+introspection endpoint.
+
+"""
+
+OAUTH2_MAX_RETRIES = 5
+"""
+Maximum number of retries when fetching URLs from the OAuth2 endpoint or OAuth2 authenticated URLs.
+This applies only to failed DNS lookups, socket connections and connection timeouts, never to
+requests where data has made it to the server.
+
+"""

--- a/automationoauth/tests/test_token.py
+++ b/automationoauth/tests/test_token.py
@@ -1,0 +1,112 @@
+"""
+Test token verification
+
+"""
+import datetime
+import json
+from unittest import mock
+from django.http import HttpRequest
+from django.test import TestCase
+from requests import Response
+from rest_framework.request import Request
+from automationoauth.token import verify_token, InvalidTokenError
+
+
+class InvalidTokenErrorTest(TestCase):
+    def test_reason(self):
+        """Passing a reason works."""
+        e = InvalidTokenError('some reason')
+        self.assertEqual(e.reason, 'some reason')
+
+    def test_no_reason(self):
+        """Passing no reason works."""
+        e = InvalidTokenError()
+        self.assertEqual(e.reason, '')
+
+
+class VerificationTest(TestCase):
+    GOOD_TOKEN = 'GOOD_TOKEN'
+    UNKNOWN_TOKEN = 'UNKNOWN_TOKEN'
+    FUTURE_TOKEN = 'FUTURE_TOKEN'
+    PAST_TOKEN = 'PAST_TOKEN'
+    NO_SUBJECT_TOKEN = 'NO_SUBJECT_TOKEN'
+
+    def setUp(self):
+        # Create an empty HTTP request
+        self.request = Request(HttpRequest())
+
+    def test_good_token(self):
+        """A request with a good token is authenticated."""
+        with self.patch_oauth2_session():
+            result = verify_token(VerificationTest.GOOD_TOKEN)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, dict)
+
+    def test_empty_subject(self):
+        """An otherwise good token with no subject is still good."""
+        with self.patch_oauth2_session():
+            result = verify_token(VerificationTest.NO_SUBJECT_TOKEN)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, dict)
+
+    def test_unknown_token(self):
+        """A completely unknown token is invalid."""
+        with self.patch_oauth2_session(), self.assertRaises(InvalidTokenError):
+            verify_token(VerificationTest.UNKNOWN_TOKEN)
+
+    def test_past_token(self):
+        """A token from the past is invalid."""
+        with self.patch_oauth2_session(), self.assertRaises(InvalidTokenError):
+            verify_token(VerificationTest.PAST_TOKEN)
+
+    def test_future_token(self):
+        """A token from the future is invalid."""
+        with self.patch_oauth2_session(), self.assertRaises(InvalidTokenError):
+            verify_token(VerificationTest.FUTURE_TOKEN)
+
+    def patch_oauth2_session(self):
+        """Patch the internal request session used by the authenticator."""
+        mock_request = mock.MagicMock()
+
+        def side_effect(*args, **kwargs):
+            token = kwargs.get('data', {}).get('token')
+
+            # By default, the response is success with inactive token
+            response = Response()
+            response.status_code = 200
+            response._content = json.dumps(dict(active=False)).encode('utf8')
+
+            if token == VerificationTest.GOOD_TOKEN:
+                response._content = json.dumps(dict(
+                    sub='testing:test0001',
+                    active=True, iat=_utc_now() - 1000, exp=_utc_now() + 1000)).encode('utf8')
+            elif token == VerificationTest.FUTURE_TOKEN:
+                response._content = json.dumps(dict(
+                    sub='testing:test0001',
+                    active=True, iat=_utc_now() + 1000, exp=_utc_now() + 3000)).encode('utf8')
+            elif token == VerificationTest.PAST_TOKEN:
+                response._content = json.dumps(dict(
+                    sub='testing:test0001',
+                    active=True, iat=_utc_now() - 3000, exp=_utc_now() - 1000)).encode('utf8')
+            elif token == VerificationTest.NO_SUBJECT_TOKEN:
+                response._content = json.dumps(dict(
+                    active=True, iat=_utc_now() - 1000, exp=_utc_now() + 1000)).encode('utf8')
+            elif token == VerificationTest.UNKNOWN_TOKEN:
+                pass  # default response suffices
+            else:
+                assert False, "Unexpected token value: {}".format(repr(token))
+
+            return response
+
+        mock_request.side_effect = side_effect
+
+        # Mock OAuth2Session to return our session mock
+        mock_get_session = mock.MagicMock()
+        mock_get_session.return_value.request = mock_request
+
+        return mock.patch('automationoauth.client.OAuth2Session', mock_get_session)
+
+
+def _utc_now():
+    """Return a UNIX-style timestamp representing "now" in UTC."""
+    return (datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds()

--- a/automationoauth/token.py
+++ b/automationoauth/token.py
@@ -1,0 +1,89 @@
+"""
+The :py:mod:`automationoauth.token` module provides support for verifying and
+introspecting tokens returned from the UIS Automation OAuth2 deployment.
+
+The response from the introspect endpoint is documented in the `Hydra API
+documentation <https://www.ory.sh/docs/api/hydra/?version=v0.11.12>`_.
+
+"""
+
+import datetime
+import logging
+from django.conf import settings
+
+from . import client
+
+LOG = logging.getLogger(__name__)
+
+
+def verify_token(token, session=None):
+    """
+    Validate an OAuth2 token and returns the parsed response from the
+    introspection endpoint if the token is valid. If the token is invalid,
+    InvalidTokenError is raised.
+
+    A valid token must be active, be issued in the past and expire in the
+    future. Note that a valid token may still lack a subject.
+
+    :param str token: Token to verify
+    :param :py:class:`automationoauth.client.AuthenticatedSession` session: Authenticated session
+       for calling Lookup proxy API.
+
+    If *session* is ``None``, the return value of
+    :py:func:`get_authenticated_session` will be used.
+
+    """
+    session = session if session is not None else get_authenticated_session()
+    r = session.request(method='POST', url=settings.OAUTH2_INTROSPECT_URL,
+                        timeout=2, data={'token': token})
+    r.raise_for_status()
+    token = r.json()
+    if not token.get('active', False):
+        raise InvalidTokenError('subject is not active')
+
+    # Get "now" in UTC
+    now = _utc_now()
+
+    if token['iat'] > now:
+        LOG.warning('Rejecting token with "iat" in the future: %s with now = %s"',
+                    token['iat'], now)
+        raise InvalidTokenError('token is from the future')
+
+    if token['exp'] < now:
+        LOG.warning('Rejecting token with "exp" in the past: %s with now = %s"',
+                    token['exp'], now)
+        raise InvalidTokenError('token has expired')
+
+    return token
+
+
+class InvalidTokenError(ValueError):
+    """
+    The passed token was invalid. The *reason* property is a human readable
+    string describing the reason why the token was invalid.
+
+    """
+    @property
+    def reason(self):
+        try:
+            return self.args[0]
+        except IndexError:
+            return ''
+
+
+def get_authenticated_session():
+    """Return a :py:class:`requests.Session` object authenticated to introspect
+    tokens. The return value is cached.
+
+    """
+    cached_session = getattr(get_authenticated_session, '_cached', None)
+    if cached_session is not None:
+        return cached_session
+    get_authenticated_session._cached = client.AuthenticatedSession(
+        scopes=settings.OAUTH2_INTROSPECT_SCOPES)
+    return get_authenticated_session()
+
+
+def _utc_now():
+    """Return a UNIX-style timestamp representing "now" in UTC."""
+    return (datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds()

--- a/automationoauthclient/__init__.py
+++ b/automationoauthclient/__init__.py
@@ -3,54 +3,8 @@ The :py:mod:`automationoauthclient.oauth2client` module provides a wrapper aroun
 :py:class:`requests.Session` which is pre-authorised with an OAuth2 client token.
 
 """
-from django.conf import settings
-from requests_oauthlib import OAuth2Session
-from requests.adapters import HTTPAdapter
-from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
+from automationoauth.client import AuthenticatedSession as _AuthenticatedSession
 
 
-class AuthenticatedSession:
-    """
-    Maintain an authenticated session as a particular OAuth2 client. The client id and secret,
-    OAUTH2_CLIENT_ID & OAUTH2_CLIENT_SECRET, are specified in the README.md.
-
-    :param sequence scopes: A sequence of strings specifying the scopes which should be requested
-        for the token.
-
-    """
-    def __init__(self, scopes):
-        self._scopes = scopes
-        self._session = None
-
-    def _get_session(self):
-        """
-        Get a :py:class:`requests.Session` object which is authenticated with the API application's
-        OAuth2 client credentials.
-
-        """
-        client = BackendApplicationClient(client_id=settings.OAUTH2_CLIENT_ID)
-        session = OAuth2Session(client=client)
-        adapter = HTTPAdapter(max_retries=settings.OAUTH2_MAX_RETRIES)
-        session.mount('http://', adapter)
-        session.mount('https://', adapter)
-        session.fetch_token(
-            timeout=2, token_url=settings.OAUTH2_TOKEN_URL,
-            client_id=settings.OAUTH2_CLIENT_ID,
-            client_secret=settings.OAUTH2_CLIENT_SECRET,
-            scope=self._scopes)
-        return session
-
-    def request(self, *args, **kwargs):
-        """
-        A version of :py:func:`requests.request` which is authenticated with the OAuth2 token for
-        this client. If the token has timed out, it is requested again.
-
-        """
-        if self._session is None:
-            self._session = self._get_session()
-
-        try:
-            return self._session.request(*args, **kwargs)
-        except TokenExpiredError:
-            self._session = self._get_session()
-            return self._session.request(*args, **kwargs)
+class AuthenticatedSession(_AuthenticatedSession):
+    pass

--- a/automationoauthdrf/tests/test_authentication.py
+++ b/automationoauthdrf/tests/test_authentication.py
@@ -146,7 +146,7 @@ class OAuth2Test(TestCase):
         mock_get_session = mock.MagicMock()
         mock_get_session.return_value.request = mock_request
 
-        return mock.patch('automationoauthclient.OAuth2Session', mock_get_session)
+        return mock.patch('automationoauth.client.OAuth2Session', mock_get_session)
 
 
 def _utc_now():

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,9 +22,8 @@ from django.conf import settings
 settings.configure(
     INSTALLED_APPS=(
         'automationlookup',
+        'automationoauth',
     ),
-    OAUTH2_LOOKUP_SCOPES=['lookup:anonymous'],
-    OAUTH2_INTROSPECT_SCOPES=['hydra.introspect'],
 )
 
 sys.path.insert(0, os.path.abspath('..'))

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,8 +1,79 @@
-OAUTH and Lookup Utilities
-==========================
+OAuth2 and Lookup Utilities
+===========================
 
 This is the documentation for the :py:mod:`django-automationoauth` project which provides a pluggable Django
 app with common utilities for authenticating requests by interacting with the LOOKUP and OAUTH services.
+
+Installation and usage
+----------------------
+
+The modules can be installed from the git repo:
+
+.. code:: bash
+
+    $ pip install git+https://github.com/uisautomation/django-automationoauth
+
+Add the following applications to ``INSTALLED_APPS``:
+
+.. code:: python
+
+    INSTALLED_APPS = [
+        # ...
+        'automationlookup',
+        'automationoauth',
+        # ...
+    ]
+
+.. note::
+
+    If you use the ``automationlookup`` application, you *must* also add the
+    ``automationoauth`` module to ``INSTALLED_APPS``.
+
+OAuth2
+------
+
+.. automodule:: automationoauth
+
+Token verification
+``````````````````
+
+.. automodule:: automationoauth.token
+    :members:
+    :member-order: bysource
+
+Authenticating as an OAuth client
+`````````````````````````````````
+
+.. automodule:: automationoauth.client
+    :members:
+    :member-order: bysource
+
+Settings
+````````
+
+.. automodule:: automationoauth.defaultsettings
+    :members:
+    :member-order: bysource
+
+Lookup
+------
+
+.. automodule:: automationlookup
+    :members:
+    :member-order: bysource
+
+Settings
+````````
+
+.. automodule:: automationlookup.defaultsettings
+    :members:
+    :member-order: bysource
+
+Legacy API
+``````````
+
+The following API was imported directly from the first project ot make use of
+our OAuth2 infrastructure and is deprecated.
 
 'authentication' module
 ```````````````````````

--- a/runtests.py
+++ b/runtests.py
@@ -14,9 +14,8 @@ settings.configure(
         'django.contrib.auth',
         'django.contrib.contenttypes',
         'automationlookup',
+        'automationoauth',
     ),
-    OAUTH2_LOOKUP_SCOPES=['lookup:anonymous'],
-    OAUTH2_INTROSPECT_SCOPES=['hydra.introspect'],
     OAUTH2_INTROSPECT_URL='http://oauth2.example.com/oauth2/introspect',
     OAUTH2_TOKEN_URL='http://oauth2.example.com/oauth2/token',
     OAUTH2_CLIENT_ID='api-client-id',
@@ -31,7 +30,8 @@ django.setup()
 test_runner = DiscoverRunner(verbosity=1)
 
 failures = test_runner.run_tests(
-    ['automationlookup', 'automationoauthclient', 'automationoauthdrf']
+    ['automationlookup', 'automationoauthclient', 'automationoauthdrf',
+     'automationoauth']
 )
 if failures:
     sys.exit(failures)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps=
     django2.0: Django>=2.0,<2.1
 commands=
     python --version
-    coverage run --source={toxinidir} --omit={toxworkdir}/* ./runtests.py {posargs}
+    coverage run --source={toxinidir} ./runtests.py {posargs}
     coverage html --directory {toxinidir}/build/htmlcov/
     coverage report
 


### PR DESCRIPTION
The lookup functionality in this module assumed that the user will have been created automatically by way of a DRF API. This is not true in, for example, the current UMP where we still use the normal Django session functionality. This assumption was wired deep in the lookup proxy and so this PR does quite some work to untangle it.

Commits 2916351, bd424b0 and 7086584 simply port some fixes from similar projects.

Commit 228e417 has the bulk of this PR and the commit message is worth reading. Since some work had already been done in thinking how a decoupled API might look in #4, this PR takes its lead from that issue and separates out the OAuth2 client, the OAuth2 token verification and the lookup proxy API into separate modules. See #4 for a discussion of the rationale for these changes.

This PR does not implement all of the changes in #4, only those which became necessary when re-working the lookup API.

It also makes sure that settings have sane default values rather than relying on upstream users to set them. This is particularly useful for "rarely changed" settings like ``LOOKUP_OAUTH2_SCOPES`` or ``INTROSPECT_OAUTH2_SCOPES``.

The OAuth2 client has simply moved to the ``automationoauth.client`` module. The token verification which was done in ``automationoauthdrf`` has been moved into its own module, ``automationoauth.token``. Both ``automationoauthclient`` and ``automationoauthdrf`` have not changed their API but now use the new modules for their implementation.

The ``automationlookup`` module had the implementation of ``get_person`` re-worked. The legacy API is untouched but has been changed to use the new API to implement it.

The ``UserLookup`` model is now redundant and can slowly be removed from projects as they move over to the new API.

The new API now looks like the following:

```python
# OAuth2 client
from automationoauth.client import AuthenticatedSession
session = AuthenticatedSession(scopes=[...])
session.request(...)

# Token verification
from automationoauth.token import verify_token
token = # ... from header
info = verify_token(token)  # raises exception if token is invalid

# Lookup
from automationlookup import get_person

# Get a person resource by CRSid
person = get_person('spqr1', fetch=['all_insts'])
```